### PR TITLE
Treat email as HTML

### DIFF
--- a/src/elm/Pages/Inbox/Model.elm
+++ b/src/elm/Pages/Inbox/Model.elm
@@ -44,15 +44,25 @@ emails =
         , teaser = "Can I get an update on the latest version of the"
         , body =
             """
-            John,
+<p>
+    John,
+</p>
 
-Can I get an update on the latest version of the proposal to working group. The meeting is on Thursday and I think it's important that we all be on the same page coming into the meeting. If everyone has had a chance to vet the document in advance, I think that we have a better chance of moving the proposal to the next stage.
+<p>
+    Can I get an update on the latest version of the proposal to working group. The meeting is on Thursday and I think it's important that we all be on the same page coming into the meeting. If everyone has had a chance to vet the document in advance, I think that we have a better chance of moving the proposal to the next stage.
+</p>
 
+    <img src="http://placehold.it/350x150">
+
+<p>
 I think the proposal has wide implications for the way we do business and it would be a shame for it to get held up at this stage because nobody had eyes on it before the meeting.
+</p>
 
+<p>
 I appreciate your attention to this!
+</p>
 
-Thanks,
+Thanks, <br/>
 Josie
 
 Josie Packard

--- a/src/elm/Pages/Inbox/View.elm
+++ b/src/elm/Pages/Inbox/View.elm
@@ -217,6 +217,7 @@ viewSelectedEmail model =
                                 ]
                             , div
                                 [ class "content__messages__selected__content"
+                                  -- Treat the email body as HTML.
                                 , property "innerHTML" <| JSON.string email.body
                                 ]
                                 []

--- a/src/elm/Pages/Inbox/View.elm
+++ b/src/elm/Pages/Inbox/View.elm
@@ -4,6 +4,7 @@ import Dict exposing (..)
 import Html exposing (..)
 import Html.Attributes exposing (..)
 import Html.Events exposing (onClick)
+import Json.Encode as JSON exposing (string)
 import Pages.Inbox.Model exposing (..)
 import Pages.Inbox.Update exposing (..)
 import Email.Model exposing (..)
@@ -214,9 +215,11 @@ viewSelectedEmail model =
                                 , div [ class "content__messages__selected__header_date" ]
                                     [ text "Tue 9/13/2016 10:26 AM" ]
                                 ]
-                            , div [ class "content__messages__selected__content" ]
-                                [ text email.body
+                            , div
+                                [ class "content__messages__selected__content"
+                                , property "innerHTML" <| JSON.string email.body
                                 ]
+                                []
                             , div [ class "ui form icon message content__messages__action" ]
                                 [ i [ class "inbox icon" ]
                                     []


### PR DESCRIPTION
PR makes Elm treat the body of the mail as an HTML. This has the advantage you can put any HTML like images/ embed inside.

![elm](https://cloud.githubusercontent.com/assets/125707/18701860/9d0d0e0c-7fe7-11e6-90fb-123c76705e4b.jpg)

@IshaDakota can you please add the `<p>` tags on the other dummy emails.